### PR TITLE
Controller support v1

### DIFF
--- a/app/game/starter_level.rb
+++ b/app/game/starter_level.rb
@@ -46,7 +46,7 @@ def tick args
     args.state.input_mode = :keyboard
   end
 
-  @show_debug = !@show_debug if args.inputs.keyboard.key_down.escape
+  @show_debug = !@show_debug if args.state.active_input.key_down?(control_mapping[:debug][args.state.input_mode])
   @paused = !@paused if args.state.active_input.key_down?(control_mapping[:pause][args.state.input_mode])
   Level.instance.debug(@show_debug)
   Level.instance.pause(@paused)
@@ -85,7 +85,7 @@ def tick args
     args.outputs.labels << [0, HEIGHT - 20, "jump: A", 0, 0, 255, 0, 0]
     args.outputs.labels << [0, HEIGHT - 40, "climb: R1", 0, 0, 255, 0, 0]
     args.outputs.labels << [0, HEIGHT - 60, "fire: MOUSE", 0, 0, 255, 0, 0]
-    args.outputs.labels << [0, HEIGHT - 80, "debug: ???", 0, 0, 255, 0, 0]
+    args.outputs.labels << [0, HEIGHT - 80, "debug: SELECT", 0, 0, 255, 0, 0]
     args.outputs.labels << [0, HEIGHT - 100, "pause: START", 0, 0, 255, 0, 0]
   end
 
@@ -129,8 +129,12 @@ def control_mapping
       controller: :r1,
     },
     pause: {
-      keyboard: :escape,
+      keyboard: :backspace,
       controller: :start,
+    },
+    debug: {
+      keyboard: :escape,
+      controller: :select,
     }
   }
 end

--- a/app/game/starter_level.rb
+++ b/app/game/starter_level.rb
@@ -47,19 +47,19 @@ def tick args
   end
 
   @show_debug = !@show_debug if args.inputs.keyboard.key_down.escape
-  @paused = !@paused if args.state.active_input.key_down.send(control_mapping[:pause][args.state.input_mode])
+  @paused = !@paused if args.state.active_input.key_down?(control_mapping[:pause][args.state.input_mode])
   Level.instance.debug(@show_debug)
   Level.instance.pause(@paused)
 
   unless @paused
-    @player.move_left if args.state.active_input.key_held.send(control_mapping[:left][args.state.input_mode])
-    @player.move_right if args.state.active_input.key_held.send(control_mapping[:right][args.state.input_mode])
-    @player.climb if args.state.active_input.key_held.send(control_mapping[:climb][args.state.input_mode])
-    @player.move_up if args.state.active_input.key_held.send(control_mapping[:up][args.state.input_mode])
-    @player.move_down if args.state.active_input.key_held.send(control_mapping[:down][args.state.input_mode])
-    if args.state.active_input.send(control_mapping[:jump][args.state.input_mode])
-      @player.jump if args.state.active_input.key_down.send(control_mapping[:jump][args.state.input_mode])
-      @player.jump_accelerate if args.state.active_input.key_held.send(control_mapping[:jump][args.state.input_mode])
+    @player.move_left if args.state.active_input.key_held?(control_mapping[:left][args.state.input_mode])
+    @player.move_right if args.state.active_input.key_held?(control_mapping[:right][args.state.input_mode])
+    @player.climb if args.state.active_input.key_held?(control_mapping[:climb][args.state.input_mode])
+    @player.move_up if args.state.active_input.key_held?(control_mapping[:up][args.state.input_mode])
+    @player.move_down if args.state.active_input.key_held?(control_mapping[:down][args.state.input_mode])
+    if args.state.active_input.key_down_or_held?(control_mapping[:jump][args.state.input_mode])
+      @player.jump if args.state.active_input.key_down?(control_mapping[:jump][args.state.input_mode])
+      @player.jump_accelerate if args.state.active_input.key_held?(control_mapping[:jump][args.state.input_mode])
     end
     @player.fire(@camera.mouse_x, @camera.mouse_y) if args.inputs.mouse.click
   end

--- a/app/game/starter_level.rb
+++ b/app/game/starter_level.rb
@@ -6,7 +6,6 @@ CANVAS_HEIGHT = 720 / 8
 MAP_SCALE = 1
 
 def init args
-  $gtk.enable_controller_config
   init_objects
   map_loader = MapLoader.new(54, 35, TILE_SIZE, "/sprites/tiles.png", 24, 21, "/data/map.csv", "/data/tiles.json", MAP_SCALE)
   @map = map_loader.map

--- a/app/game/starter_level.rb
+++ b/app/game/starter_level.rb
@@ -47,7 +47,7 @@ def tick args
   end
 
   @show_debug = !@show_debug if args.inputs.keyboard.key_down.escape
-  @paused = !@paused if args.inputs.keyboard.key_down.backspace
+  @paused = !@paused if args.state.active_input.key_down.send(control_mapping[:pause][args.state.input_mode])
   Level.instance.debug(@show_debug)
   Level.instance.pause(@paused)
 
@@ -72,12 +72,24 @@ def tick args
     @resetting = true
   end
 
-  args.outputs.labels << [0, HEIGHT, "move: W, A, S, D", 0, 0, 255, 0, 0]
-  args.outputs.labels << [0, HEIGHT - 20, "jump: SPACE", 0, 0, 255, 0, 0]
-  args.outputs.labels << [0, HEIGHT - 40, "climb: SHIFT", 0, 0, 255, 0, 0]
-  args.outputs.labels << [0, HEIGHT - 60, "fire: MOUSE", 0, 0, 255, 0, 0]
-  args.outputs.labels << [0, HEIGHT - 80, "debug: ESCAPE", 0, 0, 255, 0, 0]
-  args.outputs.labels << [0, HEIGHT - 100, "pause: BACKSPACE", 0, 0, 255, 0, 0]
+  case args.state.input_mode
+  when :keyboard
+    args.outputs.labels << [0, HEIGHT, "move: W, A, S, D", 0, 0, 255, 0, 0]
+    args.outputs.labels << [0, HEIGHT - 20, "jump: SPACE", 0, 0, 255, 0, 0]
+    args.outputs.labels << [0, HEIGHT - 40, "climb: SHIFT", 0, 0, 255, 0, 0]
+    args.outputs.labels << [0, HEIGHT - 60, "fire: MOUSE", 0, 0, 255, 0, 0]
+    args.outputs.labels << [0, HEIGHT - 80, "debug: ESCAPE", 0, 0, 255, 0, 0]
+    args.outputs.labels << [0, HEIGHT - 100, "pause: BACKSPACE", 0, 0, 255, 0, 0]
+  when :controller
+    args.outputs.labels << [0, HEIGHT, "move: d-pad or sticks", 0, 0, 255, 0, 0]
+    args.outputs.labels << [0, HEIGHT - 20, "jump: A", 0, 0, 255, 0, 0]
+    args.outputs.labels << [0, HEIGHT - 40, "climb: R1", 0, 0, 255, 0, 0]
+    args.outputs.labels << [0, HEIGHT - 60, "fire: MOUSE", 0, 0, 255, 0, 0]
+    args.outputs.labels << [0, HEIGHT - 80, "debug: ???", 0, 0, 255, 0, 0]
+    args.outputs.labels << [0, HEIGHT - 100, "pause: START", 0, 0, 255, 0, 0]
+  end
+
+
 
   args.outputs.labels << [0, HEIGHT - 300, "actors: #{Level.instance.actors.length}", 0, 0, 0, 0, 255]
   args.outputs.labels << [0, HEIGHT - 320, "solids: #{Level.instance.solids.length}", 0, 0, 0, 0, 255]
@@ -115,6 +127,10 @@ def control_mapping
     climb: {
       keyboard: :shift_left,
       controller: :r1,
+    },
+    pause: {
+      keyboard: :escape,
+      controller: :start,
     }
   }
 end

--- a/app/game/starter_level.rb
+++ b/app/game/starter_level.rb
@@ -46,20 +46,20 @@ def tick args
     args.state.input_mode = :keyboard
   end
 
-  @show_debug = !@show_debug if args.state.active_input.key_down?(control_mapping[:debug][args.state.input_mode])
-  @paused = !@paused if args.state.active_input.key_down?(control_mapping[:pause][args.state.input_mode])
+  @show_debug = !@show_debug if args.state.active_input.key_down?(control_mapping[:debug])
+  @paused = !@paused if args.state.active_input.key_down?(control_mapping[:pause])
   Level.instance.debug(@show_debug)
   Level.instance.pause(@paused)
 
   unless @paused
-    @player.move_left if args.state.active_input.key_held?(control_mapping[:left][args.state.input_mode])
-    @player.move_right if args.state.active_input.key_held?(control_mapping[:right][args.state.input_mode])
-    @player.climb if args.state.active_input.key_held?(control_mapping[:climb][args.state.input_mode])
-    @player.move_up if args.state.active_input.key_held?(control_mapping[:up][args.state.input_mode])
-    @player.move_down if args.state.active_input.key_held?(control_mapping[:down][args.state.input_mode])
-    if args.state.active_input.key_down_or_held?(control_mapping[:jump][args.state.input_mode])
-      @player.jump if args.state.active_input.key_down?(control_mapping[:jump][args.state.input_mode])
-      @player.jump_accelerate if args.state.active_input.key_held?(control_mapping[:jump][args.state.input_mode])
+    @player.move_left if args.state.active_input.key_held?(control_mapping[:left])
+    @player.move_right if args.state.active_input.key_held?(control_mapping[:right])
+    @player.climb if args.state.active_input.key_held?(control_mapping[:climb])
+    @player.move_up if args.state.active_input.key_held?(control_mapping[:up])
+    @player.move_down if args.state.active_input.key_held?(control_mapping[:down])
+    if args.state.active_input.key_down_or_held?(control_mapping[:jump])
+      @player.jump if args.state.active_input.key_down?(control_mapping[:jump])
+      @player.jump_accelerate if args.state.active_input.key_held?(control_mapping[:jump])
     end
     @player.fire(@camera.mouse_x, @camera.mouse_y) if args.inputs.mouse.click
   end
@@ -104,39 +104,27 @@ end
 
 def control_mapping
   {
-    jump: {
-      keyboard: :space,
-      controller: :a,
+    keyboard: {
+      jump: :space,
+      left: :a,
+      right: :d,
+      up: :w,
+      down: :s,
+      climb: :shift_left,
+      pause: :backspace,
+      debug: :escape,
     },
-    left: {
-      keyboard: :a,
-      controller: :left
-    },
-    right: {
-      keyboard: :d,
-      controller: :right,
-    },
-    up: {
-      keyboard: :w,
-      controller: :up,
-    },
-    down: {
-      keyboard: :s,
-      controller: :down,
-    },
-    climb: {
-      keyboard: :shift_left,
-      controller: :r1,
-    },
-    pause: {
-      keyboard: :backspace,
-      controller: :start,
-    },
-    debug: {
-      keyboard: :escape,
-      controller: :select,
+    controller: {
+      jump: :a,
+      left: :left,
+      right: :right,
+      up: :up,
+      down: :down,
+      climb: :r1,
+      pause: :start,
+      debug: :select,
     }
-  }
+  }[$args.state.input_mode]
 end
 
 def reset args


### PR DESCRIPTION
This is an early stab at adding controller support - I'm not sure this is the best implementation but it worked for me to get the demo to run using a controller, seems to work great!

## Things I didn't change

#### You still fire by clicking the mouse

I wasn't sure what would work best for someone using a controller here - one pattern I've seen is that your right stick controls your crosshair and your left stick or D-pad controls movement and we draw a crosshair near the player based on where the right stick is (and just leave it in place if the right stick is not being used). I thought this could work but it would have involved adding another sprite and maintaining state for that crosshair, and not everyone likes crosshairs.

An alternative approach would have been to just make it so that the right stick decides your angle and not show a crosshair and the player can figure it out by firing (maybe the "b" or "x" button?), but I have not done either yet. I could have sworn there was a helper in `inputs` that would let you find the angle of the stick but I think I am misrembering and it's something like `left|right_analog_x_perc` and `y_perc`: https://docs.dragonruby.org/#/api/inputs?id=leftright_analog_x_perc

For my project I am still trying to figure out if I want to do anything involving firing projectiles at all, so I didn't need this yet 😅 

#### I didn't make controls remappable

For now the control mapping is hard coded. I thought R1 made sense for climb (although when I was trying this out, it took a second to understand - I'm curious if a better name for this might be "grip" or "hold onto"). The mapping function could probably be changed to load either a default mapping or a configured one out of saved state if someone needed to later.


_I tested this using a Logitech F-310 controller in "D" Input mode, following these instructions: https://gist.github.com/jackblk/8138827afd986f30cf9d26647e8448e1_